### PR TITLE
remove forced space character from prefix

### DIFF
--- a/plugins/shell/src/lib.rs
+++ b/plugins/shell/src/lib.rs
@@ -34,7 +34,7 @@ fn info() -> PluginInfo {
 }
 
 fn get_matches(input: RString, config: &mut Config) -> RVec<Match> {
-    let prefix_with_delim = format!("{} ", config.prefix);
+    let prefix_with_delim = format!("{}", config.prefix);
     if input.starts_with(&prefix_with_delim) {
         let (_, command) = input.split_once(&prefix_with_delim).unwrap();
         if !command.is_empty() {


### PR DESCRIPTION
Hi,

I've just removed the forced empty space in the prefix so you can configure f.e. "!" and just type "!shutdown now" instead of "! shutdown now" .... or even simply not have a prefix by configuring `prefix: ""`.

Regards