### PR TITLE
Escape characters for pango markup

### DIFF
--- a/plugins/symbols/src/lib.rs
+++ b/plugins/symbols/src/lib.rs
@@ -70,10 +70,22 @@ fn get_matches(input: RString, symbols: &mut Vec<Symbol>) -> RVec<Match> {
 
     symbols.truncate(3);
 
+    // escape certain characters for pango markup
+    fn escape_chr(chr: &str) -> &str {
+        match chr {
+            "&" => "&amp;",
+            "<" => "&lt;",
+            ">" => "&gt;",
+            "\"" => "&quot;",
+            "'" => "&apos;",
+            chr => chr,
+        }
+    }
+
     symbols
         .into_iter()
         .map(|(symbol, _)| Match {
-            title: symbol.chr.into(),
+            title: escape_chr(&symbol.chr).into(),
             description: ROption::RSome(symbol.name.into()),
             icon: ROption::RNone,
             id: ROption::RNone,


### PR DESCRIPTION
This PR fixes unescaped characters from the symbols plugin being interpreted as pango markup. E.g., typing/searching `a` with the default config matches the `&` symbol and gives the following warning:
```
Failed to set text '&' from markup due to error parsing markup: Error on line 1: Entity did not end with a semicolon; most likely you used an ampersand character without intending to start an entity — escape ampersand as &amp;
```
I'm not sure if other plugins need escaping. If so, this might warrant a config option to interpret the `title` and/or `description` as non-pango text.

An alternative implementation could use [`markup_escape_text`](https://docs.gtk.org/glib/func.markup_escape_text.html) from glib. Also, [here](https://gitlab.gnome.org/GNOME/glib/-/blob/main/glib/gmarkup.c#L2218) is some relevant source code.