### PR TITLE
Add use_pango option for Match

### DIFF
--- a/anyrun-interface/src/lib.rs
+++ b/anyrun-interface/src/lib.rs
@@ -30,13 +30,15 @@ pub struct PluginInfo {
 
 /// Represents a match from a plugin
 ///
-/// The `title` and `description` support pango markup.
+/// The `title` and `description` support pango markup when `use_pango` is set to true.
 /// Refer to [Pango Markup](https://docs.gtk.org/Pango/pango_markup.html) for how to use pango markup.
 #[repr(C)]
 #[derive(StableAbi, Clone)]
 pub struct Match {
     pub title: RString,
     pub description: ROption<RString>,
+    /// Whether the title and description should be interpreted as pango markup.
+    pub use_pango: bool,
     /// The icon name from the icon theme in use
     pub icon: ROption<RString>,
     /// For runners to differentiate between the matches. Not required.

--- a/anyrun/src/main.rs
+++ b/anyrun/src/main.rs
@@ -589,7 +589,7 @@ fn handle_matches(
         let title = gtk::Label::builder()
             .name(style_names::MATCH_TITLE)
             .wrap(true)
-            .use_markup(true) // Allow pango markup
+            .use_markup(_match.use_pango)
             .halign(gtk::Align::Start)
             .valign(gtk::Align::Center)
             .vexpand(true)
@@ -610,7 +610,7 @@ fn handle_matches(
                     &gtk::Label::builder()
                         .name(style_names::MATCH_DESC)
                         .wrap(true)
-                        .use_markup(true) // Allow pango markup
+                        .use_markup(_match.use_pango)
                         .halign(gtk::Align::Start)
                         .valign(gtk::Align::Center)
                         .label(desc)

--- a/plugins/applications/src/lib.rs
+++ b/plugins/applications/src/lib.rs
@@ -73,8 +73,9 @@ pub fn get_matches(input: RString, entries: &mut Vec<(DesktopEntry, u64)>) -> RV
         .into_iter()
         .map(|(entry, id, _)| Match {
             title: entry.name.into(),
-            icon: ROption::RSome(entry.icon.into()),
             description: entry.desc.map(|desc| desc.into()).into(),
+            use_pango: false,
+            icon: ROption::RSome(entry.icon.into()),
             id: ROption::RSome(id),
         })
         .collect()

--- a/plugins/kidex/src/lib.rs
+++ b/plugins/kidex/src/lib.rs
@@ -77,18 +77,21 @@ pub fn get_matches(input: RString, state: &mut State) -> RVec<Match> {
                 Match {
                     title: "Open File".into(),
                     description: ROption::RSome(path.clone().into()),
+                    use_pango: false,
                     id: ROption::RSome(IndexAction::Open as u64),
                     icon: ROption::RSome("document-open".into()),
                 },
                 Match {
                     title: "Copy Path".into(),
                     description: ROption::RSome(path.into()),
+                    use_pango: false,
                     id: ROption::RSome(IndexAction::CopyPath as u64),
                     icon: ROption::RSome("edit-copy".into()),
                 },
                 Match {
                     title: "Back".into(),
                     description: ROption::RNone,
+                    use_pango: false,
                     id: ROption::RSome(IndexAction::Back as u64),
                     icon: ROption::RSome("edit-undo".into()),
                 },
@@ -119,16 +122,17 @@ pub fn get_matches(input: RString, state: &mut State) -> RVec<Match> {
                         .file_name()
                         .map(|name| name.to_string_lossy().into())
                         .unwrap_or("N/A".into()),
-                    icon: ROption::RSome(if entry_index.directory {
-                        "folder".into()
-                    } else {
-                        "text-x-generic".into()
-                    }),
                     description: entry_index
                         .path
                         .parent()
                         .map(|path| path.display().to_string().into())
                         .into(),
+                    use_pango: false,
+                    icon: ROption::RSome(if entry_index.directory {
+                        "folder".into()
+                    } else {
+                        "text-x-generic".into()
+                    }),
                     id: ROption::RSome(id as u64),
                 })
                 .collect()

--- a/plugins/rink/src/lib.rs
+++ b/plugins/rink/src/lib.rs
@@ -42,8 +42,9 @@ fn get_matches(input: RString, ctx: &mut rink_core::Context) -> RVec<Match> {
     match rink_core::one_line(ctx, &input) {
         Ok(result) => vec![Match {
             title: result.into(),
-            icon: ROption::RNone,
             description: ROption::RNone,
+            use_pango: false,
+            icon: ROption::RNone,
             id: ROption::RNone,
         }]
         .into(),

--- a/plugins/shell/src/lib.rs
+++ b/plugins/shell/src/lib.rs
@@ -51,6 +51,7 @@ fn get_matches(input: RString, config: &mut Config) -> RVec<Match> {
                         })
                         .into(),
                 ),
+                use_pango: false,
                 icon: ROption::RNone,
                 id: ROption::RNone,
             }]

--- a/plugins/symbols/src/lib.rs
+++ b/plugins/symbols/src/lib.rs
@@ -75,6 +75,7 @@ fn get_matches(input: RString, symbols: &mut Vec<Symbol>) -> RVec<Match> {
         .map(|(symbol, _)| Match {
             title: symbol.chr.into(),
             description: ROption::RSome(symbol.name.into()),
+            use_pango: false,
             icon: ROption::RNone,
             id: ROption::RNone,
         })

--- a/plugins/translate/src/lib.rs
+++ b/plugins/translate/src/lib.rs
@@ -217,6 +217,7 @@ fn get_matches(input: RString, data: &mut RuntimeData) -> RVec<Match> {
                                     }).expect("Google API returned unknown language code!"),
                                     name)
                                 .into()),
+                            use_pango: false,
                             icon: ROption::RNone,
                             id: ROption::RNone
                         }


### PR DESCRIPTION
This allows plugins to specify whether or not to interpret the `title` and `description` of each `Match` as pango markup.
Let me know if anything needs changing.