### PR TITLE
Fix out of bounds panic

### DIFF
--- a/anyrun/src/main.rs
+++ b/anyrun/src/main.rs
@@ -390,15 +390,16 @@ fn activate(app: &gtk::Application, runtime_data: Rc<RefCell<Option<RuntimeData>
                     Some(selected) => selected,
                     None => {
                         // If nothing is selected select either the top or bottom match based on the input
-                        match event.keyval() {
-                            _ if combined_matches.is_empty() => (),
-                            constants::Down | constants::Tab => combined_matches[0]
-                                .1
-                                .select_row(Some(&combined_matches[0].0)),
-                            constants::Up => combined_matches[combined_matches.len() - 1]
-                                .1
-                                .select_row(Some(&combined_matches[combined_matches.len() - 1].0)),
-                            _ => unreachable!(),
+                        if !combined_matches.is_empty() {
+                            match event.keyval() {
+                                constants::Down | constants::Tab => combined_matches[0]
+                                    .1
+                                    .select_row(Some(&combined_matches[0].0)),
+                                constants::Up => combined_matches[combined_matches.len() - 1]
+                                    .1
+                                    .select_row(Some(&combined_matches[combined_matches.len() - 1].0)),
+                                _ => unreachable!(),
+                            }
                         }
                         return Inhibit(true);
                     }

--- a/anyrun/src/main.rs
+++ b/anyrun/src/main.rs
@@ -391,6 +391,7 @@ fn activate(app: &gtk::Application, runtime_data: Rc<RefCell<Option<RuntimeData>
                     None => {
                         // If nothing is selected select either the top or bottom match based on the input
                         match event.keyval() {
+                            _ if combined_matches.is_empty() => (),
                             constants::Down | constants::Tab => combined_matches[0]
                                 .1
                                 .select_row(Some(&combined_matches[0].0)),


### PR DESCRIPTION
Using the up arrow, down arrow, or tab key with no text input causes a panic.