### PR TITLE
feat: add nix flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,0 @@
-use flake

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/README.md
+++ b/README.md
@@ -67,6 +67,45 @@ You can use the flake:
 }
 ```
 
+_Note: The flake does not install the plugins anywhere like /etc/anyrun/plugins.
+Make sure to specify full paths to the plugins in your config,
+by managing it in Nix/home-manager, and using the full path, like this (in hm):_
+
+```nix
+  xdg.configFile."anyrun/config.ron".text = ''
+    Config(
+      // `width` and `vertical_offset` use an enum for the value it can be either:
+      // Absolute(n): The absolute value in pixels
+      // Fraction(n): A fraction of the width or height of the full screen (depends on exclusive zones and the settings related to them) window respectively
+
+      // How wide the input box and results are.
+      width: Absolute(800),
+
+      // Where Anyrun is located on the screen: Top, Center
+      position: Top,
+
+      // How much the runner is shifted vertically
+      vertical_offset: Fraction(0.3),
+
+      // Hide match and plugin info icons
+      hide_icons: false,
+
+      // ignore exclusive zones, f.e. Waybar
+      ignore_exclusive_zones: false,
+
+      // Layer shell layer: Background, Bottom, Top, Overlay
+      layer: Overlay,
+
+      // Hide the plugin info panel
+      hide_plugin_info: true,
+
+      plugins: [
+        "${pkgs.anyrun}/lib/libapplications.so",
+      ],
+    )
+  '';
+```
+
 ### Manual installation
 
 Make sure all of the dependencies are installed, and then run the following commands in order:

--- a/README.md
+++ b/README.md
@@ -36,6 +36,37 @@ Here are the libraries you need to have to build & run it:
 
 If you use an Arch based distro, you can install the AUR package [anyrun-git](https://aur.archlinux.org/packages/anyrun-git).
 
+### Nix
+
+You can use the flake:
+
+```nix
+# flake.nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    anyrun.url = "github:Kirottu/anyrun";
+    anyrun.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = { self, nixpkgs, anyrun }: let
+    pkgs = import nixpkgs {
+      system = system;
+      overlays = [anyrun.overlay];
+      allowUnfree = true;
+    };
+  in {
+    nixosConfigurations.HOSTNAME = nixpkgs.lib.nixosSystem {
+      # ...
+
+      system.packages = [ pkgs.anyrun ];
+
+      # ...
+    };
+  };
+}
+```
+
 ### Manual installation
 
 Make sure all of the dependencies are installed, and then run the following commands in order:

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,65 @@
+# default.nix
+{
+  lib,
+  naersk,
+  glib,
+  targetPlatform,
+  makeWrapper,
+  atk,
+  gtk3,
+  gtk-layer-shell,
+  pkg-config,
+  librsvg,
+  rustfmt,
+  cargo,
+  rustc,
+}: let
+  cargoToml = builtins.fromTOML (builtins.readFile ./anyrun/Cargo.toml);
+in
+  naersk.lib."${targetPlatform.system}".buildPackage {
+    src = ./.;
+
+    buildInputs = [
+      pkg-config
+      glib
+      atk
+      gtk3
+      librsvg
+      gtk-layer-shell
+    ];
+    checkInputs = [cargo rustc];
+
+    nativeBuildInputs = [
+      makeWrapper
+      rustfmt
+      rustc
+      cargo
+    ];
+
+    doCheck = true;
+    CARGO_BUILD_INCREMENTAL = "false";
+    RUST_BACKTRACE = "full";
+    copyLibs = true;
+
+    name = cargoToml.package.name;
+    version = cargoToml.package.version;
+
+    postInstall = ''
+      wrapProgram $out/bin/anyrun \
+        --set GDK_PIXBUF_MODULE_FILE "$(echo ${librsvg.out}/lib/gdk-pixbuf-2.0/*/loaders.cache)"
+    '';
+
+    meta = with lib; {
+      description = "A wayland native, highly customizable runner.";
+      homepage = "https://github.com/Kirottu/anyrun";
+      license = with licenses; [gpl3];
+      maintainers = [
+        {
+          email = "neo@neoney.dev";
+          github = "n3oney";
+          githubId = 30625554;
+          name = "Michał Minarowski";
+        }
+      ];
+    };
+  }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "naersk": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1679567394,
+        "narHash": "sha256-ZvLuzPeARDLiQUt6zSZFGOs+HZmE+3g4QURc8mkBsfM=",
+        "owner": "nmattia",
+        "repo": "naersk",
+        "rev": "88cd22380154a2c36799fe8098888f0f59861a15",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nmattia",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1682109806,
+        "narHash": "sha256-d9g7RKNShMLboTWwukM+RObDWWpHKaqTYXB48clBWXI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2362848adf8def2866fabbffc50462e929d7fffb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,77 @@
+{
+  description = "A wayland native, highly customizable runner.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    naersk = {
+      url = "github:nmattia/naersk";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    naersk,
+  }: let
+    cargoToml = builtins.fromTOML (builtins.readFile ./anyrun/Cargo.toml);
+    supportedSystems = ["x86_64-linux" "aarch64-linux"];
+    forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f system);
+  in {
+    overlay = final: prev: {
+      "${cargoToml.package.name}" = final.callPackage ./. {inherit naersk;};
+    };
+
+    packages = forAllSystems (system: let
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [self.overlay];
+      };
+    in {
+      "${cargoToml.package.name}" = pkgs."${cargoToml.package.name}";
+    });
+
+    defaultPackage = forAllSystems (system:
+      (import nixpkgs {
+        inherit system;
+        overlays = [self.overlay];
+      })
+      ."${cargoToml.package.name}");
+
+    checks = forAllSystems (system: let
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [
+          self.overlay
+        ];
+      };
+    in {
+      format =
+        pkgs.runCommand "check-format"
+        {
+          buildInputs = with pkgs; [rustfmt cargo];
+        } ''
+          ${pkgs.rustfmt}/bin/cargo-fmt fmt --manifest-path ${./anyrun}/Cargo.toml -- --check
+          ${pkgs.nixpkgs-fmt}/bin/nixpkgs-fmt --check ${./anyrun}
+          touch $out # it worked!
+        '';
+      "${cargoToml.package.name}" = pkgs."${cargoToml.package.name}";
+    });
+    devShell = forAllSystems (system: let
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [self.overlay];
+      };
+    in
+      pkgs.mkShell {
+        inputsFrom = [
+          pkgs."${cargoToml.package.name}"
+        ];
+        buildInputs = with pkgs; [
+          rustfmt
+          nixpkgs-fmt
+        ];
+        LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+      });
+  };
+}


### PR DESCRIPTION
This PR adds a flake, to allow Nix(OS) users to install anyrun easily.

It doesn't have any configuration options or nix/home-manager modules.

The plugins are also built with the flake, kept in `lib/`, so to be able to use anyrun, you have to specify the full path to the plugin inside your configuration file. (like `"${pkgs.anyrun}/lib/libapplications.so"`
The above is documented.

The fact you have to use full paths will also allow plugins to be possibly packaged separately and used in the configs very easily.

Have confirmed with another person that it works for them!