### PR TITLE
fix deprecated URL literal

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ nix.settings = {
     builders-use-substitutes = true;
     # substituters to use
     substituters = [
-        https://anyrun.cachix.org
+        "https://anyrun.cachix.org"
     ];
 
     trusted-public-keys = [


### PR DESCRIPTION
forgot those were a thing, easy fix to invalid syntax for the cache URL