### PR TITLE
Temporary fix for CI

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         package:
           - anyrun
-          - defaultPackage
+          - ""
     steps:
       - uses: easimon/maximize-build-space@v6
         with:


### PR DESCRIPTION
Using empty string so it defaults to defaultPackage automatically as a temporary fix for CI until the rewrite of nix module is complete