### PR TITLE
feat(applications): handle `Path` field in desktop entries

### DIFF
--- a/plugins/applications/src/lib.rs
+++ b/plugins/applications/src/lib.rs
@@ -3,7 +3,7 @@ use anyrun_plugin::{anyrun_interface::HandleResult, *};
 use fuzzy_matcher::FuzzyMatcher;
 use scrubber::DesktopEntry;
 use serde::Deserialize;
-use std::{fs, process::Command};
+use std::{env, fs, process::Command};
 
 #[derive(Deserialize)]
 pub struct Config {
@@ -65,7 +65,12 @@ pub fn handler(selection: Match, state: &State) -> HandleResult {
                 }
             }
         }
-    } else if let Err(why) = Command::new("sh").arg("-c").arg(&entry.exec).spawn() {
+    } else if let Err(why) = Command::new("sh")
+        .arg("-c")
+        .arg(&entry.exec)
+        .current_dir(entry.path.as_ref().unwrap_or(&env::current_dir().unwrap()))
+        .spawn()
+    {
         eprintln!("Error running desktop entry: {}", why);
     }
 

--- a/plugins/applications/src/scrubber.rs
+++ b/plugins/applications/src/scrubber.rs
@@ -74,7 +74,7 @@ impl DesktopEntry {
                                 }
                                 exec
                             },
-                            path: map.get("Path").map(|val| PathBuf::from(val)),
+                            path: map.get("Path").map(PathBuf::from),
                             name: map.get("Name")?.to_string(),
                             desc: None,
                             icon: map

--- a/plugins/applications/src/scrubber.rs
+++ b/plugins/applications/src/scrubber.rs
@@ -1,10 +1,11 @@
-use std::{collections::HashMap, env, ffi::OsStr, fs};
+use std::{collections::HashMap, env, ffi::OsStr, fs, path::PathBuf};
 
 use crate::Config;
 
 #[derive(Clone, Debug)]
 pub struct DesktopEntry {
     pub exec: String,
+    pub path: Option<PathBuf>,
     pub name: String,
     pub desc: Option<String>,
     pub icon: String,
@@ -73,6 +74,7 @@ impl DesktopEntry {
                                 }
                                 exec
                             },
+                            path: map.get("Path").map(|val| PathBuf::from(val)),
                             name: map.get("Name")?.to_string(),
                             desc: None,
                             icon: map
@@ -118,6 +120,7 @@ impl DesktopEntry {
                                 }
                                 None => continue,
                             },
+                            path: entry.path.clone(),
                             name: match map.get("Name") {
                                 Some(name) => name.to_string(),
                                 None => continue,


### PR DESCRIPTION
Some desktop entries are required to be run under a certain directory; for instance, the desktop entries created by https://github.com/quickemu-project/quickemu.

I'm new to Rust, so any feedback is appreciated.