### PR TITLE
nix: fix non-null max_entries value in home-manager module

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -217,7 +217,7 @@ in {
             max_entries: ${
             if cfg.config.maxEntries == null
             then "None"
-            else builtins.toString cfg.config.maxEntries
+            else "Some(${builtins.toString cfg.config.maxEntries})"
           },
             plugins: ${builtins.toJSON parsedPlugins},
           )


### PR DESCRIPTION
Properly wraps the value of max_entries in the config.ron generated by home-manager with Some() when non-null, since that's what anyrun expects.