### PR TITLE
fix: specify valid default value

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -76,7 +76,7 @@ in {
       };
 
       y = mkNumericOption {
-        default.fraction = 0;
+        default.fraction = 0.0;
         description = mdDoc ''
           The vertical position, works the same as x.
 


### PR DESCRIPTION
bruh why tf is 0 not a valid float