### PR TITLE
nix: speed up nix build by only building sub directories

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -56,6 +56,7 @@ in
     CARGO_BUILD_INCREMENTAL = "false";
     RUST_BACKTRACE = "full";
     copyLibs = true;
+    buildAndTestSubdir = if dontBuildPlugins then name else null;
 
     postInstall = ''
       wrapProgram $out/bin/anyrun \

--- a/nix/plugins/default.nix
+++ b/nix/plugins/default.nix
@@ -40,6 +40,7 @@ in
     RUST_BACKTRACE = "full";
     copyLibs = true;
     cargoBuildFlags = ["-p ${name}"];
+    buildAndTestSubdir = "plugins/${name}";
 
     meta = with lib; {
       description = "The ${name} plugin for Anyrun";


### PR DESCRIPTION
Building the nix packages currently takes a long time as it compiles the dependencies of all the members of the cargo workspace.

Setting `buildAndTestSubdir` greatly speeds up the build.