### PR TITLE
feat: added plugin to search for xdg user directories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1014,6 +1014,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "home"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "http"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2379,6 +2388,16 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+]
+
+[[package]]
+name = "userdirs"
+version = "0.1.0"
+dependencies = [
+ "abi_stable",
+ "anyrun-plugin",
+ "fuzzy-matcher",
+ "home",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,5 @@ members = [
   "plugins/randr",
   "plugins/stdin",
   "plugins/dictionary",
+  "plugins/userdirs",
 ]

--- a/plugins/userdirs/Cargo.toml
+++ b/plugins/userdirs/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "userdirs"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+anyrun-plugin = { path = "../../anyrun-plugin" }
+abi_stable = "0.11.1"
+fuzzy-matcher = "0.3.7"
+home = "0.5.5"

--- a/plugins/userdirs/src/lib.rs
+++ b/plugins/userdirs/src/lib.rs
@@ -1,0 +1,102 @@
+use std::fs::File;
+
+use std::io::{self, BufRead};
+use std::path::Path;
+use std::process::Command;
+
+use fuzzy_matcher::FuzzyMatcher;
+
+use abi_stable::std_types::{ROption, RString, RVec};
+use anyrun_plugin::*;
+
+pub struct State {
+    dirs: Vec<String>,
+}
+
+#[init]
+fn init(_config_dir: RString) -> State {
+    let mut dirs: Vec<String> = vec![];
+
+    match home::home_dir() {
+        Some(path) => {
+            if let Ok(lines) = read_lines(format!("{}/.config/user-dirs.dirs", path.display())) {
+                for line in lines {
+                    if let Ok(entry) = line {
+                        if entry.starts_with("XDG_") {
+                            match entry.split_once("=") {
+                                Some((_, suffix)) => {
+                                    let cleaned = suffix
+                                        .replace("\"", "")
+                                        .trim_start_matches("$HOME/")
+                                        .to_string();
+                                    dirs.push(cleaned);
+                                }
+                                None => (),
+                            };
+                        }
+                    }
+                }
+            }
+        }
+        None => println!("Impossible to get your home dir!"),
+    }
+
+    State { dirs }
+}
+
+#[info]
+fn info() -> PluginInfo {
+    PluginInfo {
+        name: "User Dirs".into(),
+        icon: "help-about".into(),
+    }
+}
+
+fn read_lines<P>(filename: P) -> io::Result<io::Lines<io::BufReader<File>>>
+where
+    P: AsRef<Path>,
+{
+    let file = File::open(filename)?;
+    Ok(io::BufReader::new(file).lines())
+}
+
+#[get_matches]
+fn get_matches(input: RString, state: &State) -> RVec<Match> {
+    let matcher = fuzzy_matcher::skim::SkimMatcherV2::default().smart_case();
+
+    let matches = state
+        .dirs
+        .clone()
+        .into_iter()
+        .filter_map(|line| {
+            matcher
+                .fuzzy_match(&line, &input)
+                .map(|score| (line, score))
+        })
+        .collect::<Vec<_>>();
+
+    matches
+        .into_iter()
+        .map(|(line, _)| Match {
+            title: line.into(),
+            description: ROption::RSome("Folder".into()),
+            use_pango: false,
+            icon: ROption::RNone,
+            id: ROption::RNone,
+        })
+        .collect::<Vec<_>>()
+        .into()
+}
+
+#[handler]
+fn handler(selection: Match) -> HandleResult {
+    if let Err(why) = Command::new("sh")
+        .arg("-c")
+        .arg(format!("xdg-open file://$HOME/{}", selection.title))
+        .spawn()
+    {
+        println!("Failed to open folder: {}", why);
+    }
+
+    HandleResult::Close
+}


### PR DESCRIPTION
Hi,

this plugin would allow you to use anyrun to search/open xdg user directories, see [here](https://wiki.archlinux.org/title/XDG_user_directories).

What do you think? Personally i use the finder rather often in order to open those directories.

Regards