### PR TITLE
Update README.md

### DIFF
--- a/plugins/dictionary/README.md
+++ b/plugins/dictionary/README.md
@@ -12,5 +12,6 @@ Type in `<prefix><word to define>`, where prefix is the configured prefix (defau
 // <Anyrun config dir>/dictionary.ron
 Config(
   prefix: ":def",
+  max_entries: 5,
 )
 ```


### PR DESCRIPTION
i checked your code , and there is no error handling available in-case of absence of **max_entries** field.
the config won't take any effect without this field.
so , it's better to include it in README also , it'll create confusion for newcomers.