### PR TITLE
Implemented search history for application plugin

### DIFF
--- a/plugins/applications/README.md
+++ b/plugins/applications/README.md
@@ -19,5 +19,7 @@ Config(
   // The terminal used for running terminal based desktop entries, if left as `None` a static list of terminals is used
   // to determine what terminal to use.
   terminal: Some("alacritty"),
+  // The history size for the application history, set to 0 to disable history
+  history_size: 50,
 )
 ```

--- a/plugins/applications/src/history.rs
+++ b/plugins/applications/src/history.rs
@@ -1,0 +1,64 @@
+use std::collections::VecDeque;
+use std::fs;
+use std::env;
+
+use crate::scrubber::DesktopEntry;
+
+
+pub struct History(VecDeque<DesktopEntry>);
+
+impl History {
+    pub fn new() -> Self {
+        Self(VecDeque::new())
+    }
+
+    pub fn load() -> Self {             
+
+        let path = format!(
+            "{}/.cache/anyrun-applications-history",
+            env::var("HOME").expect("Unable to determine HOME directory")
+        );
+
+        if let Ok(content) = fs::read_to_string(&path) {
+            let mut history: VecDeque<DesktopEntry> = ron::from_str(&content).unwrap_or_else(|why| {
+                eprintln!("Error parsing history: {}", why);
+                VecDeque::new()
+            });            
+            return Self(history);
+        }
+
+        Self::new()
+    }
+
+    pub fn write(&self) {
+
+        let path = format!(
+            "{}/.cache/anyrun-applications-history",
+            env::var("HOME").expect("Unable to determine HOME directory")
+        );
+
+        let content = ron::to_string(&self.0).unwrap_or_else(|why| {
+            eprintln!("Error serializing history: {}", why);
+            String::new()
+        });
+        if let Err(why) = fs::write(&path, content) {
+            eprintln!("Error writing history: {}", why);
+        }
+    }
+    pub fn add_entry(&mut self, entry: DesktopEntry) {
+        
+        self.0.push_back(entry);
+    }
+
+    pub fn truncate(&mut self, max_entries: usize) {
+        self.0.truncate(max_entries);
+    }
+
+    pub fn get_entry_info(&self, entry: &DesktopEntry) -> Option<(usize, usize)> {        
+        let index = self.0.iter().position(|x| x == entry)?;
+        let count = self.0.iter().filter(|x| *x == entry).count();
+        Some((index, count))
+    }
+
+}
+

--- a/plugins/applications/src/lib.rs
+++ b/plugins/applications/src/lib.rs
@@ -109,19 +109,6 @@ pub fn init(config_dir: RString) -> State {
     State { config, entries, history }
 }
 
-fn format_entries(entries: Vec<(&DesktopEntry, u64)>) -> RVec<Match> {
-    entries
-    .into_iter()
-    .map(|(entry, id)| Match {
-        title: entry.name.clone().into(),
-        description: entry.desc.clone().map(|desc| desc.into()).into(),
-        use_pango: false,
-        icon: ROption::RSome(entry.icon.clone().into()),
-        id: ROption::RSome(id),
-    })
-    .collect()
-}
-
 #[get_matches]
 pub fn get_matches(input: RString, state: &State) -> RVec<Match> {
 

--- a/plugins/applications/src/scrubber.rs
+++ b/plugins/applications/src/scrubber.rs
@@ -1,8 +1,10 @@
 use std::{collections::HashMap, env, ffi::OsStr, fs, path::PathBuf};
 
+use serde::{Deserialize, Serialize};
+
 use crate::Config;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct DesktopEntry {
     pub exec: String,
     pub path: Option<PathBuf>,


### PR DESCRIPTION
Issue #14 discussed this feature before, but the branch the maintainer mentioned is out of date by 74 commits.

This pull request implements recency bias into the applications plugin, meaning recently / commonly searched applications will be prioritized. The history file is stored in `$HOME/.cache/anyrun-applications-history`. The maximum number of entries can be changed in the config file using `history_size` (see README.md).

Recency bias is only applied if the other score components are not 0 (to prevent unrelated results showing up) and when the input field is empty. 
