### PR TITLE
Replace `-o` with `--plugins` in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Anyrun requires plugins to function, as they provide the results for input. The 
   - TODO: Only supports Hyprland, needs support for other compositors.
 - [Stdin](plugins/stdin/README.md)
   - Turn Anyrun into a dmenu like fuzzy selector.
-  - Should generally be used exclusively with the `-o` argument.
+  - Should generally be used exclusively with the `--plugins` argument.
 - [Dictionary](plugins/dictionary/README.md)
   - Look up definitions for words
 - [Websearch](plugins/websearch/README.md)

--- a/plugins/stdin/README.md
+++ b/plugins/stdin/README.md
@@ -5,5 +5,5 @@ Allows for easy integration into scripts that have been made with something like
 
 ## Usage
 
-This plugin should generally be used alone, if a dmenu replacement is needed. This can be done with `anyrun -o libstdin.so`.
+This plugin should generally be used alone, if a dmenu replacement is needed. This can be done with `anyrun --plugins libstdin.so`.
 The content to fuzzy match on needs to be piped into Anyrun.


### PR DESCRIPTION
Hello,

I just notice that in some place the documentation was steal using `-o` to load a plugin even if isn't a valid parameter anymore, so I replaced it with `--plugins`.