### PR TITLE
fix: Desktop Entries without proper path wouldn't run

### DIFF
--- a/plugins/applications/src/lib.rs
+++ b/plugins/applications/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature()]
-
 use abi_stable::std_types::{ROption, RString, RVec};
 use anyrun_plugin::{anyrun_interface::HandleResult, *};
 use fuzzy_matcher::FuzzyMatcher;


### PR DESCRIPTION
The desktop entries edited by applications like kmenuedit will leave blank in the path, and that causes the `current_dir` of the command to become `""`, making `os error 2 (no such file or directory)`.

Now it would try to run in env::current_dir if the path was not set or not proper