### PR TITLE
Custom image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+
+.idea

--- a/anyrun-interface/src/lib.rs
+++ b/anyrun-interface/src/lib.rs
@@ -41,6 +41,8 @@ pub struct Match {
     pub use_pango: bool,
     /// The icon name from the icon theme in use
     pub icon: ROption<RString>,
+    /// The path to a custom image to use instead of an icon
+    pub image: ROption<RString>,
     /// For runners to differentiate between the matches. Not required.
     pub id: ROption<u64>,
 }

--- a/anyrun/src/main.rs
+++ b/anyrun/src/main.rs
@@ -37,6 +37,10 @@ struct Config {
 
     #[serde(default)]
     hide_icons: bool,
+    #[serde(default = "Config::default_max_image_width")]
+    max_image_width: i32,
+    #[serde(default = "Config::default_max_image_height")]
+    max_image_height: i32,
     #[serde(default)]
     hide_plugin_info: bool,
     #[serde(default)]
@@ -77,6 +81,14 @@ impl Config {
         ]
     }
 
+    fn default_max_image_width() -> i32 {
+        150
+    }
+
+    fn default_max_image_height() -> i32 {
+        100
+    }
+
     fn default_layer() -> Layer {
         Layer::Overlay
     }
@@ -91,6 +103,8 @@ impl Default for Config {
             height: Self::default_height(),
             plugins: Self::default_plugins(),
             hide_icons: false,
+            max_image_width: 150,
+            max_image_height: 100,
             hide_plugin_info: false,
             ignore_exclusive_zones: false,
             close_on_click: false,
@@ -196,6 +210,8 @@ mod style_names {
 
     pub const MATCH_TITLE: &str = "match-title";
     pub const MATCH_DESC: &str = "match-desc";
+    pub const MATCH_ICON: &str = "match-icon";
+    pub const MATCH_IMAGE: &str = "match-image";
 }
 
 /// Default config directory
@@ -714,9 +730,20 @@ fn handle_matches(plugin_view: PluginView, runtime_data: &RuntimeData, matches: 
             .hexpand(true)
             .build();
         if !runtime_data.config.hide_icons {
-            if let ROption::RSome(icon) = &_match.icon {
+            if let ROption::RSome(image) = &_match.image {
                 let mut builder = gtk::Image::builder()
-                    .name(style_names::MATCH)
+                    .name(style_names::MATCH_IMAGE);
+
+                match gdk_pixbuf::Pixbuf::from_file_at_size(image.as_str(), runtime_data.config.max_image_width, runtime_data.config.max_image_height) {
+                    Ok(pixbuf) => {
+                        builder = builder.pixbuf(&pixbuf);
+                        hbox.add(&builder.build());
+                    },
+                    Err(why) => println!("Failed to load image file: {}", why)
+                }
+            } else if let ROption::RSome(icon) = &_match.icon {
+                let mut builder = gtk::Image::builder()
+                    .name(style_names::MATCH_ICON)
                     .pixel_size(32);
 
                 let path = PathBuf::from(icon.as_str());

--- a/anyrun/src/main.rs
+++ b/anyrun/src/main.rs
@@ -210,8 +210,6 @@ mod style_names {
 
     pub const MATCH_TITLE: &str = "match-title";
     pub const MATCH_DESC: &str = "match-desc";
-    pub const MATCH_ICON: &str = "match-icon";
-    pub const MATCH_IMAGE: &str = "match-image";
 }
 
 /// Default config directory
@@ -732,7 +730,7 @@ fn handle_matches(plugin_view: PluginView, runtime_data: &RuntimeData, matches: 
         if !runtime_data.config.hide_icons {
             if let ROption::RSome(image) = &_match.image {
                 let mut builder = gtk::Image::builder()
-                    .name(style_names::MATCH_IMAGE);
+                    .name(style_names::MATCH);
 
                 match gdk_pixbuf::Pixbuf::from_file_at_size(image.as_str(), runtime_data.config.max_image_width, runtime_data.config.max_image_height) {
                     Ok(pixbuf) => {
@@ -743,7 +741,7 @@ fn handle_matches(plugin_view: PluginView, runtime_data: &RuntimeData, matches: 
                 }
             } else if let ROption::RSome(icon) = &_match.icon {
                 let mut builder = gtk::Image::builder()
-                    .name(style_names::MATCH_ICON)
+                    .name(style_names::MATCH)
                     .pixel_size(32);
 
                 let path = PathBuf::from(icon.as_str());

--- a/anyrun/src/main.rs
+++ b/anyrun/src/main.rs
@@ -729,15 +729,18 @@ fn handle_matches(plugin_view: PluginView, runtime_data: &RuntimeData, matches: 
             .build();
         if !runtime_data.config.hide_icons {
             if let ROption::RSome(image) = &_match.image {
-                let mut builder = gtk::Image::builder()
-                    .name(style_names::MATCH);
+                let mut builder = gtk::Image::builder().name(style_names::MATCH);
 
-                match gdk_pixbuf::Pixbuf::from_file_at_size(image.as_str(), runtime_data.config.max_image_width, runtime_data.config.max_image_height) {
+                match gdk_pixbuf::Pixbuf::from_file_at_size(
+                    image.as_str(),
+                    runtime_data.config.max_image_width,
+                    runtime_data.config.max_image_height,
+                ) {
                     Ok(pixbuf) => {
                         builder = builder.pixbuf(&pixbuf);
                         hbox.add(&builder.build());
-                    },
-                    Err(why) => println!("Failed to load image file: {}", why)
+                    }
+                    Err(why) => println!("Failed to load image file: {}", why),
                 }
             } else if let ROption::RSome(icon) = &_match.icon {
                 let mut builder = gtk::Image::builder()

--- a/examples/config.ron
+++ b/examples/config.ron
@@ -19,10 +19,10 @@ Config(
   hide_icons: false,
 
   // The maximum width of custom images
-  max_image_width: 100,
+  max_image_width: 150,
 
   // The maximum height of custom images
-  max_image_height: 50,
+  max_image_height: 100,
 
   // ignore exclusive zones, f.e. Waybar  
   ignore_exclusive_zones: false, 

--- a/examples/config.ron
+++ b/examples/config.ron
@@ -16,7 +16,13 @@ Config(
   height: Absolute(0),
   
   // Hide match and plugin info icons  
-  hide_icons: false, 
+  hide_icons: false,
+
+  // The maximum width of custom images
+  max_image_width: 100,
+
+  // The maximum height of custom images
+  max_image_height: 50,
 
   // ignore exclusive zones, f.e. Waybar  
   ignore_exclusive_zones: false, 

--- a/plugins/applications/src/lib.rs
+++ b/plugins/applications/src/lib.rs
@@ -143,6 +143,7 @@ pub fn get_matches(input: RString, state: &State) -> RVec<Match> {
             description: entry.desc.clone().map(|desc| desc.into()).into(),
             use_pango: false,
             icon: ROption::RSome(entry.icon.clone().into()),
+            image: ROption::RNone,
             id: ROption::RSome(id),
         })
         .collect()

--- a/plugins/applications/src/lib.rs
+++ b/plugins/applications/src/lib.rs
@@ -122,7 +122,7 @@ pub fn get_matches(input: RString, state: &State) -> RVec<Match> {
 
             // prioritize actions
             if entry.desc.is_some() {
-                score = score * 2;
+                score *= 2;
             }
 
             if score > 0 {

--- a/plugins/dictionary/src/lib.rs
+++ b/plugins/dictionary/src/lib.rs
@@ -89,6 +89,7 @@ pub fn get_matches(input: RString, config: &Config) -> RVec<Match> {
                             description: ROption::RSome(meaning.part_of_speech.clone().into()),
                             use_pango: false,
                             icon: ROption::RSome("accessories-dictionary".into()),
+                            image: ROption::RNone,
                             id: ROption::RNone,
                         })
                         .collect::<RVec<_>>()

--- a/plugins/kidex/src/lib.rs
+++ b/plugins/kidex/src/lib.rs
@@ -102,6 +102,7 @@ pub fn get_matches(input: RString, state: &State) -> RVec<Match> {
                     use_pango: false,
                     id: ROption::RSome(IndexAction::Open as u64),
                     icon: ROption::RSome("document-open".into()),
+                    image: ROption::RNone,
                 },
                 Match {
                     title: "Copy Path".into(),
@@ -109,6 +110,7 @@ pub fn get_matches(input: RString, state: &State) -> RVec<Match> {
                     use_pango: false,
                     id: ROption::RSome(IndexAction::CopyPath as u64),
                     icon: ROption::RSome("edit-copy".into()),
+                    image: ROption::RNone,
                 },
                 Match {
                     title: "Back".into(),
@@ -116,6 +118,7 @@ pub fn get_matches(input: RString, state: &State) -> RVec<Match> {
                     use_pango: false,
                     id: ROption::RSome(IndexAction::Back as u64),
                     icon: ROption::RSome("edit-undo".into()),
+                    image: ROption::RNone,
                 },
             ]
             .into()
@@ -155,6 +158,7 @@ pub fn get_matches(input: RString, state: &State) -> RVec<Match> {
                     } else {
                         "text-x-generic".into()
                     }),
+                    image: ROption::RNone,
                     id: ROption::RSome(id as u64),
                 })
                 .collect()

--- a/plugins/randr/src/lib.rs
+++ b/plugins/randr/src/lib.rs
@@ -124,6 +124,7 @@ pub fn get_matches(input: RString, state: &State) -> RVec<Match> {
                 ),
                 use_pango: false,
                 icon: ROption::RSome("object-flip-horizontal".into()),
+                image: ROption::RNone,
                 id: ROption::RSome(mon.id),
             })
             .collect::<RVec<_>>(),
@@ -150,6 +151,7 @@ pub fn get_matches(input: RString, state: &State) -> RVec<Match> {
                                 description: ROption::RNone,
                                 use_pango: false,
                                 icon: ROption::RSome(configure.icon().into()),
+                                image: ROption::RNone,
                                 // Store 2 32 bit IDs in the single 64 bit integer, a bit of a hack
                                 id: ROption::RSome(_mon.id << 32 | Into::<u64>::into(configure)),
                             })
@@ -165,6 +167,7 @@ pub fn get_matches(input: RString, state: &State) -> RVec<Match> {
                 description: ROption::RNone,
                 use_pango: false,
                 icon: ROption::RSome(Configure::Zero.icon().into()),
+                image: ROption::RNone,
                 id: ROption::RSome((&Configure::Zero).into()),
             });
 
@@ -173,6 +176,7 @@ pub fn get_matches(input: RString, state: &State) -> RVec<Match> {
                 description: ROption::RSome("Return to the previous menu".into()),
                 use_pango: false,
                 icon: ROption::RSome("edit-undo".into()),
+                image: ROption::RNone,
                 id: ROption::RSome(u64::MAX),
             });
 

--- a/plugins/rink/src/lib.rs
+++ b/plugins/rink/src/lib.rs
@@ -50,6 +50,7 @@ fn get_matches(input: RString, ctx: &mut rink_core::Context) -> RVec<Match> {
                 description: desc.map(RString::from).into(),
                 use_pango: false,
                 icon: ROption::RNone,
+                image: ROption::RNone,
                 id: ROption::RNone,
             }]
             .into()

--- a/plugins/shell/src/lib.rs
+++ b/plugins/shell/src/lib.rs
@@ -55,6 +55,7 @@ fn get_matches(input: RString, config: &Config) -> RVec<Match> {
                 ),
                 use_pango: false,
                 icon: ROption::RNone,
+                image: ROption::RNone,
                 id: ROption::RNone,
             }]
             .into()

--- a/plugins/stdin/src/lib.rs
+++ b/plugins/stdin/src/lib.rs
@@ -68,12 +68,16 @@ fn get_matches(input: RString, state: &State) -> RVec<Match> {
 
     lines
         .into_iter()
-        .map(|(line, _)| Match {
-            title: line.into(),
-            description: ROption::RNone,
-            use_pango: false,
-            icon: ROption::RNone,
-            id: ROption::RNone,
+        .map(|(line, _)| {
+            let mut line = line.split("\t");
+            Match {
+                title: line.next().unwrap_or("".into()).into(),
+                description: ROption::RNone,
+                use_pango: false,
+                icon: ROption::RNone,
+                image: line.next().map_or(ROption::RNone, |p| ROption::RSome(p.into())),
+                id: ROption::RNone,
+            }
         })
         .collect::<Vec<_>>()
         .into()

--- a/plugins/stdin/src/lib.rs
+++ b/plugins/stdin/src/lib.rs
@@ -75,7 +75,9 @@ fn get_matches(input: RString, state: &State) -> RVec<Match> {
                 description: ROption::RNone,
                 use_pango: false,
                 icon: ROption::RNone,
-                image: line.next().map_or(ROption::RNone, |p| ROption::RSome(p.into())),
+                image: line
+                    .next()
+                    .map_or(ROption::RNone, |p| ROption::RSome(p.into())),
                 id: ROption::RNone,
             }
         })

--- a/plugins/stdin/src/lib.rs
+++ b/plugins/stdin/src/lib.rs
@@ -35,7 +35,7 @@ fn init(config_dir: RString) -> State {
 
     State {
         config,
-        lines: stdin().lines().filter_map(|line| line.ok()).collect(),
+        lines: stdin().lines().map_while(Result::ok).collect(),
     }
 }
 
@@ -69,9 +69,9 @@ fn get_matches(input: RString, state: &State) -> RVec<Match> {
     lines
         .into_iter()
         .map(|(line, _)| {
-            let mut line = line.split("\t");
+            let mut line = line.split('\t');
             Match {
-                title: line.next().unwrap_or("".into()).into(),
+                title: line.next().unwrap_or("").into(),
                 description: ROption::RNone,
                 use_pango: false,
                 icon: ROption::RNone,

--- a/plugins/symbols/src/lib.rs
+++ b/plugins/symbols/src/lib.rs
@@ -92,6 +92,7 @@ fn get_matches(input: RString, state: &State) -> RVec<Match> {
             description: ROption::RSome(symbol.name.clone().into()),
             use_pango: false,
             icon: ROption::RNone,
+            image: ROption::RNone,
             id: ROption::RNone,
         })
         .collect()

--- a/plugins/translate/src/lib.rs
+++ b/plugins/translate/src/lib.rs
@@ -276,6 +276,7 @@ fn get_matches(input: RString, state: &State) -> RVec<Match> {
                                 .into()),
                             use_pango: false,
                             icon: ROption::RNone,
+                            image: ROption::RNone,
                             id: ROption::RNone
                         }
                     )

--- a/plugins/translate/src/lib.rs
+++ b/plugins/translate/src/lib.rs
@@ -211,7 +211,12 @@ fn get_matches(input: RString, state: &State) -> RVec<Match> {
 
             let mut matches = src_matches
                 .into_iter()
-                .flat_map(|src| dest_matches.clone().into_iter().map(move |dest| (Some(src), dest)))
+                .flat_map(|src| {
+                    dest_matches
+                        .clone()
+                        .into_iter()
+                        .map(move |dest| (Some(src), dest))
+                })
                 .collect::<Vec<_>>();
 
             matches.sort_by(|a, b| (b.1 .2 + b.0.unwrap().2).cmp(&(a.1 .2 + a.0.unwrap().2)));
@@ -237,12 +242,12 @@ fn get_matches(input: RString, state: &State) -> RVec<Match> {
             .into_iter()
             .map(|(src, dest)| async move {
                 match src {
-                    Some(src) => 
+                    Some(src) =>
                 (dest.1, state.client.get(format!("https://translate.googleapis.com/translate_a/single?client=gtx&sl={}&tl={}&dt=t&q={}", src.0, dest.0, text)).send().await),
                     None => (dest.1, state.client.get(format!("https://translate.googleapis.com/translate_a/single?client=gtx&sl=auto&tl={}&dt=t&q={}", dest.0, text)).send().await)
                 }
             });
-       
+
         let res = futures::future::join_all(futures) // Wait for all futures to complete
             .await;
 

--- a/plugins/websearch/src/lib.rs
+++ b/plugins/websearch/src/lib.rs
@@ -82,6 +82,7 @@ fn get_matches(input: RString, config: &Config) -> RVec<Match> {
                 description: ROption::RSome(format!("Search with {}", engine).into()),
                 use_pango: false,
                 icon: ROption::RNone,
+                image: ROption::RNone,
                 id: ROption::RSome(i as u64),
             })
             .collect()


### PR DESCRIPTION
Implements custom image support in the `Match` object, and adds support for it in the Stdin plugin (without breaking anything).

Feel free to point out anything I should change/forgot, a few key things I couldn't decide on myself:
- Should `hide_icons` also hide images? Or should images always be shown? Or should they have their own switch? I went with the first option because custom images are supposed to override icons, sort of.
- This is not really up to decision, because GTK CSS does not support changing the size of `GtkImage`s, but I had to go with having a max width and height in the config file instead.
- The default values for the 2 options mentioned above are undecided, I put 150 for max width, and 100 for max height.
- For the Stdin implementation, the title and the image path are separated by a tab character. How should I go about also adding support for normal icons in Stdin? (e.g.: have a specifier before the path -> `image:/path/to/image.png`, `icon:/path/to/image.png`, `icon:help-about `

Breaking changes:
- Plugins need to add the new field
- (Not really) 2 new config fields

Closes #126 