### PR TITLE
Add a note for installing xdg-utils as a dependency of the websearch plugin

### DIFF
--- a/plugins/websearch/README.md
+++ b/plugins/websearch/README.md
@@ -25,3 +25,17 @@ Config(
   engines: [Google] 
 )
 ```
+## Notes
+This plugin relies on xdg-open and won't work without it. On NixOS, this can be installed by adding `xdg-utils` to your list of packages:
+```nix
+environment.systemPackages = with pkgs; [
+  xdg-utils
+];
+```
+
+Or, with home-manager:
+```nix
+home.packages = with pkgs; [
+  xdg-utils
+];
+```


### PR DESCRIPTION
The websearch plugin relies on `xdg-open`, which does not always come preinstalled on every system. This should therefore be mentioned on the README.